### PR TITLE
Slight changes to message output with /check <#> command

### DIFF
--- a/proxy/src/main/java/org/cubeville/cvchat/tickets/TicketManager.java
+++ b/proxy/src/main/java/org/cubeville/cvchat/tickets/TicketManager.java
@@ -195,10 +195,11 @@ public class TicketManager implements IPCInterface
         }
 
         sender.sendMessage("§eFiled by §c" + ticket.getPlayerName() + "§e at " + getDateStr(ticket.getCreationTimestamp()) + "§e at " + ticket.getServer() + "," + ticket.getWorld() + "," + ticket.getX() + "," + ticket.getY() + "," + ticket.getZ());
-        if(ticket.isClaimed() || ticket.isClosed()) {
-            sender.sendMessage("§eHandled by §d" + ticket.getModeratorName() + "§e at §d" + getDateStr(ticket.getModeratorTimestamp()));
+        if(!ticket.isClosed() && ticket.isClaimed()) {
+            sender.sendMessage("§eClaimed by §d" + ticket.getModeratorName() + "§e at §d" + getDateStr(ticket.getModeratorTimestamp()));
         }
-        if(ticket.isClosed()) {
+        else if(ticket.isClosed()) {
+            sender.sendMessage("§eHandled by §d" + ticket.getModeratorName() + "§e at §d" + getDateStr(ticket.getModeratorTimestamp()));
             sender.sendMessage("§6Mod comment - §7" + ticket.getModeratorText());
         }
         sender.sendMessage("§7" + ticket.getText());


### PR DESCRIPTION
If modreq is open and claimed, message will be "Claimed by" when using /check <#>, and "Handled by" only when it it closed, to avoid confusion when checking the details of the message.